### PR TITLE
Add MobX store for auth token

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "dayjs": "^1.11.13",
         "embla-carousel": "8.5.2",
         "embla-carousel-react": "8.5.2",
+        "mobx": "^6.13.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.6.1",
@@ -610,6 +611,8 @@
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mobx": ["mobx@6.13.7", "", {}, "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
         "dayjs": "^1.11.13",
         "embla-carousel": "8.5.2",
         "embla-carousel-react": "8.5.2",
+        "mobx": "^6.13.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.6.1",

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -2,12 +2,20 @@ import { createORPCClient } from '@orpc/client';
 import { RPCLink } from '@orpc/client/fetch';
 import { ContractRouterClient } from '@orpc/contract';
 import { contract } from '@shared/contract';
+import { store } from '@/store';
 
 const SERVER_URL = import.meta.env.VITE_SERVER_URL || 'http://localhost:3000';
 
 const link = new RPCLink({
     url: `${SERVER_URL}/rpc`,
-    headers: () => ({}),
+    headers: () => {
+        if (store.token) {
+            return { Authorization: `Bearer ${store.token}` };
+        }
+
+        return {};
+    },
 });
 
-export const client: ContractRouterClient<typeof contract> = createORPCClient(link);
+export const client: ContractRouterClient<typeof contract> =
+    createORPCClient(link);

--- a/client/src/pages/Login/PasswordForm.tsx
+++ b/client/src/pages/Login/PasswordForm.tsx
@@ -3,6 +3,7 @@ import { useForm } from '@mantine/form';
 import { UserButton } from './UserButton';
 import type { FrontendUser } from '@shared/types';
 import { client } from '@/client';
+import { store } from '@/store';
 
 type PasswordFormProps = {
     user: FrontendUser;
@@ -15,16 +16,21 @@ export function PasswordForm({ user, onBack }: PasswordFormProps) {
             password: '',
         },
         validate: {
-            password: (value) => (value.length < 4 ? 'Password must be at least 4 characters' : null),
+            password: (value) =>
+                value.length < 4
+                    ? 'Password must be at least 4 characters'
+                    : null,
         },
     });
 
     const handleSubmit = async (values: { password: string }) => {
         try {
-            await client.auth.login({
+            const response = await client.auth.login({
                 id: user.id,
                 password: values.password,
             });
+
+            store.setToken(response.token);
         } catch (error) {
             console.error(error);
             form.setFieldError('password', 'Invalid password');
@@ -46,17 +52,10 @@ export function PasswordForm({ user, onBack }: PasswordFormProps) {
                 {...form.getInputProps('password')}
             />
             <Stack gap="xs" mt="md">
-                <Button
-                    fullWidth
-                    type="submit"
-                >
+                <Button fullWidth type="submit">
                     Login
                 </Button>
-                <Button
-                    fullWidth
-                    variant="subtle"
-                    onClick={onBack}
-                >
+                <Button fullWidth variant="subtle" onClick={onBack}>
                     Back
                 </Button>
             </Stack>

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -1,0 +1,29 @@
+import { makeAutoObservable } from 'mobx';
+
+const TOKEN_KEY = 'token';
+
+export class Store {
+    token: string | null = null;
+
+    constructor() {
+        makeAutoObservable(this);
+
+        if (typeof window !== 'undefined') {
+            const stored = window.localStorage.getItem(TOKEN_KEY);
+            this.token = stored ? stored : null;
+        }
+    }
+
+    setToken(token: string | null) {
+        this.token = token;
+        if (typeof window !== 'undefined') {
+            if (token === null) {
+                window.localStorage.removeItem(TOKEN_KEY);
+            } else {
+                window.localStorage.setItem(TOKEN_KEY, token);
+            }
+        }
+    }
+}
+
+export const store = new Store();


### PR DESCRIPTION
## Summary
- add MobX as a client dependency
- implement `Store` class with automatic token persistence
- store login token after successful login
- attach token to RPC requests via headers

## Testing
- `bun run format`
- `bun run build:client`


------
https://chatgpt.com/codex/tasks/task_e_683f4559eebc832996b4188897b54b34