### PR TITLE
Add router and whoami

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,63 @@
-import './App.css';
-import { Login } from '@/pages/Login/Login';
+import { useEffect, useState } from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router';
+import { Center, Loader } from '@mantine/core';
+import { Login } from '@/pages/Login';
+import { Home } from '@/pages/Home';
+import { store } from '@/store';
+import { autorun } from 'mobx';
+import { client } from '@/client';
+import type { FrontendUser } from '@shared/types';
+
 
 export const App = () => {
-    return <Login />;
+    const [token, setToken] = useState(store.token);
+    const [user, setUser] = useState<FrontendUser | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        const dispose = autorun(() => {
+            setToken(store.token);
+        });
+        return dispose;
+    }, []);
+
+    useEffect(() => {
+        if (!token) {
+            setUser(null);
+            return;
+        }
+
+        setLoading(true);
+        client.auth
+            .whoami()
+            .then(u => {
+                setUser(u);
+                setLoading(false);
+            })
+            .catch(err => {
+                console.error(err);
+                store.setToken(null);
+                setLoading(false);
+            });
+    }, [token]);
+
+    if (!token) {
+        return <Login />;
+    }
+
+    if (loading || user === null) {
+        return (
+            <Center h="100vh">
+                <Loader size="md" type="dots" color="blue" />
+            </Center>
+        );
+    }
+
+    return (
+        <BrowserRouter>
+            <Routes>
+                <Route index element={<Home />} />
+            </Routes>
+        </BrowserRouter>
+    );
 };

--- a/client/src/components/Shell.tsx
+++ b/client/src/components/Shell.tsx
@@ -1,9 +1,10 @@
+import type { PropsWithChildren } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { AppShell, Group, Burger, Skeleton } from '@mantine/core';
 import Logo from '@/assets/logo.svg?react';
 import './Shell.css';
 
-export const Shell = () => {
+export const Shell = ({ children }: PropsWithChildren<{}>) => {
     const [opened, { toggle }] = useDisclosure();
 
     return (
@@ -40,7 +41,7 @@ export const Shell = () => {
                         <Skeleton key={index} h={28} mt="sm" animate={false} />
                     ))}
             </AppShell.Navbar>
-            <AppShell.Main>Main</AppShell.Main>
+            <AppShell.Main>{children}</AppShell.Main>
         </AppShell>
     );
 };

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,6 +1,9 @@
-import './App.css';
 import { Shell } from '@/components/Shell';
 
 export const Home = () => {
-    return <Shell />;
+    return (
+        <Shell>
+            <div>Home</div>
+        </Shell>
+    );
 };

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -7,21 +7,16 @@ export class Store {
 
     constructor() {
         makeAutoObservable(this);
-
-        if (typeof window !== 'undefined') {
-            const stored = window.localStorage.getItem(TOKEN_KEY);
-            this.token = stored ? stored : null;
-        }
+        const stored = window.localStorage.getItem(TOKEN_KEY);
+        this.token = stored ? stored : null;
     }
 
     setToken(token: string | null) {
         this.token = token;
-        if (typeof window !== 'undefined') {
-            if (token === null) {
-                window.localStorage.removeItem(TOKEN_KEY);
-            } else {
-                window.localStorage.setItem(TOKEN_KEY, token);
-            }
+        if (token === null) {
+            window.localStorage.removeItem(TOKEN_KEY);
+        } else {
+            window.localStorage.setItem(TOKEN_KEY, token);
         }
     }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,7 +11,7 @@ const rpcHandler = new RPCHandler(rpcRouter);
 app.use('/rpc/*', async (c, next) => {
     const { matched, response } = await rpcHandler.handle(c.req.raw, {
         prefix: '/rpc',
-        context: {},
+        context: { headers: c.req.raw.headers },
     });
 
     if (matched) {

--- a/server/src/middleware/withAuth.ts
+++ b/server/src/middleware/withAuth.ts
@@ -1,0 +1,39 @@
+import { implement } from '@orpc/server';
+import { contract } from '@shared/contract';
+import type { RuntimeData } from '../RuntimeData';
+
+export const osWithHeaders = implement(contract).$context<{ headers: Headers }>();
+
+export const withAuth = (data: RuntimeData) =>
+    osWithHeaders.middleware(({ context, next }) => {
+            const token = context.headers.get('authorization')?.split(' ')[1];
+
+            if (!token) {
+                throw new Error('Unauthorized');
+            }
+
+            const session = data.sessions.find(s => s.token === token);
+
+            if (!session) {
+                throw new Error('Unauthorized');
+            }
+
+            const user = data.users.find(u => u.id === session.userId);
+
+            if (!user) {
+                throw new Error('Unauthorized');
+            }
+
+            return next({
+                context: {
+                    user: {
+                        id: user.id,
+                        name: user.name,
+                        avatar: user.avatar,
+                    },
+                },
+            });
+        });
+
+
+

--- a/server/src/rpcRouter.ts
+++ b/server/src/rpcRouter.ts
@@ -1,21 +1,21 @@
-import { implement } from '@orpc/server';
-import { contract } from '@shared/contract';
 import { RuntimeData } from './RuntimeData';
+import { withAuth, osWithHeaders } from './middleware/withAuth';
 import _ from 'lodash';
 
-const os = implement(contract);
+const osHeaders = osWithHeaders;
 const data = new RuntimeData();
 
-export const rpcRouter = os.router({
+
+export const rpcRouter = osHeaders.router({
     auth: {
-        getUsers: os.auth.getUsers.handler(async () =>
+        getUsers: osHeaders.auth.getUsers.handler(async () =>
             _.map(data.users, user => ({
                 id: user.id,
                 name: user.name,
                 avatar: user.avatar,
             }))
         ),
-        login: os.auth.login.handler(async ({ input }) => {
+        login: osHeaders.auth.login.handler(async ({ input }) => {
             const { id, password } = input;
             const user = _.find(data.users, { id, password });
 
@@ -40,5 +40,8 @@ export const rpcRouter = os.router({
                 token,
             };
         }),
+        whoami: osHeaders.auth.whoami
+            .use(withAuth(data))
+            .handler(async ({ context }) => context.user),
     }
 });

--- a/shared/src/contract.ts
+++ b/shared/src/contract.ts
@@ -20,9 +20,18 @@ const login = oc
         token: z.string(),
     }));
 
+const whoami = oc.output(
+    z.object({
+        id: z.string(),
+        name: z.string(),
+        avatar: z.string(),
+    }),
+);
+
 export const contract = {
     auth: {
         getUsers,
         login,
+        whoami,
     },
 };


### PR DESCRIPTION
## Summary
- setup whoami rpc contract and endpoint
- pass headers to RPC context
- use browser localStorage directly for token handling
- create Shell layout and add react-router with login check
- refactor whoami auth middleware

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_683f483ca6748329b73e7df8ff6ab99f