### PR TITLE
Use lowdb for runtime data

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "dependencies": {
         "@orpc/server": "^1.3.0",
         "hono": "^4.7.11",
+        "lowdb": "^7.0.1",
         "shared": "workspace:*",
         "zod": "^3.25.49",
       },
@@ -610,6 +611,8 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
+    "lowdb": ["lowdb@7.0.1", "", { "dependencies": { "steno": "^4.0.2" } }, "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw=="],
+
     "lower-case": ["lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -777,6 +780,8 @@
     "snake-case": ["snake-case@3.0.4", "", { "dependencies": { "dot-case": "^3.0.4", "tslib": "^2.0.3" } }, "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "steno": ["steno@4.0.2", "", {}, "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/server/migrations/001-default-users.ts
+++ b/server/migrations/001-default-users.ts
@@ -1,0 +1,34 @@
+import type { Low } from 'lowdb';
+import { UserRole } from '@shared/types';
+import _ from 'lodash';
+import { generateUniqueId } from '../src/utils/generateUniqueId';
+
+export default async (db: Low<unknown>) => {
+    const data =
+        (db.data as {
+            users?: Array<{
+                id: string;
+                name: string;
+                password: string;
+                avatar?: string;
+                role: UserRole;
+            }>;
+            sessions?: unknown[];
+        }) || {};
+
+    data.users ||= [];
+    data.sessions ||= [];
+
+    if (data.users.length > 0) {
+        return;
+    }
+
+    const uniqueId = () => generateUniqueId(_.map(data.users ?? [], 'id'));
+
+    data.users.push({
+        id: uniqueId(),
+        name: 'Admin',
+        password: 'admin',
+        role: UserRole.Admin,
+    });
+};

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "dependencies": {
         "@orpc/server": "^1.3.0",
         "hono": "^4.7.11",
+        "lowdb": "^7.0.1",
         "shared": "workspace:*",
         "zod": "^3.25.49"
     },

--- a/server/src/Migrator.ts
+++ b/server/src/Migrator.ts
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { Low } from 'lowdb';
+import _ from 'lodash';
+import type { DbData } from './db';
+
+export class Migrator {
+    constructor(private db: Low<DbData>, private dir = path.join(process.cwd(), 'migrations')) {}
+
+    async migrate() {
+        await this.db.read();
+        this.db.data ||= { users: [], sessions: [], _migrations: [] };
+
+        const applied = this.db.data!._migrations || [];
+        let files: string[] = [];
+        try {
+            files = await fs.readdir(this.dir);
+        } catch {
+            return;
+        }
+
+        const migrations = files.filter(f => f.endsWith('.ts')).sort();
+        const pending = _.difference(migrations, applied);
+        if (pending.length === 0) return;
+
+        for (const file of pending) {
+            const modulePath = path.join(this.dir, file);
+            const migration = await import(modulePath);
+            if (typeof migration.default === 'function') {
+                await migration.default(this.db);
+            }
+            applied.push(file);
+        }
+        await this.db.write();
+    }
+}

--- a/server/src/RuntimeData.ts
+++ b/server/src/RuntimeData.ts
@@ -1,48 +1,28 @@
-import { UserRole, type FrontendUser, type Session, type User } from '@shared/types';
+import type { FrontendUser, Session } from '@shared/types';
 import _ from 'lodash';
+import { db, getDatabase } from './db';
 
 export class RuntimeData {
-    users: User[] = [
-        {
-            id: '1',
-            name: 'Alice',
-            password: 'password1',
-            avatar: 'https://randomuser.me/api/portraits/women/68.jpg',
-            role: UserRole.Admin,
-        },
-        {
-            id: '2',
-            name: 'Bob',
-            password: 'password2',
-            avatar: 'https://randomuser.me/api/portraits/men/32.jpg',
-            role: UserRole.User,
-        },
-        {
-            id: '3',
-            name: 'Charlie',
-            password: 'password3',
-            avatar: 'https://randomuser.me/api/portraits/men/85.jpg',
-            role: UserRole.ReadOnly,
-        },
-    ];
-
-    sessions: Session[] = [];
-
     async getUsers(): Promise<FrontendUser[]> {
-        return this.users.map(user => ({
-            id: user.id,
-            name: user.name,
-            avatar: user.avatar,
-            role: user.role,
-        }));
+        const db = getDatabase();
+        return db.chain
+            .get('users')
+            .map((user) => ({
+                id: user.id,
+                name: user.name,
+                avatar: user.avatar,
+                role: user.role,
+            }))
+            .value();
     }
 
     async whoami(token: string): Promise<FrontendUser> {
-        const session = this.sessions.find(session => session.token === token);
+        const db = getDatabase();
+        const session = db.chain.get('sessions').find({ token }).value();
         if (!session) {
             throw new Error('Unauthorized');
         }
-        const user = this.users.find(user => user.id === session.userId);
+        const user = db.chain.get('users').find({ id: session.userId }).value();
         if (!user) {
             throw new Error('User not found');
         }
@@ -55,7 +35,8 @@ export class RuntimeData {
     }
 
     async login(userId: string, password: string) {
-        const user = _.find(this.users, { id: userId, password });
+        const db = getDatabase();
+        const user = db.chain.get('users').find({ id: userId, password }).value();
         if (!user) {
             throw new Error('Invalid credentials');
         }
@@ -63,10 +44,13 @@ export class RuntimeData {
     }
 
     async spawnSession(userId: string) {
-        const existingSession = _.find(this.sessions, { userId });
+        const db = getDatabase();
+        const existingSession = db.chain.get('sessions').find({ userId }).value();
 
         if (existingSession) {
-            this.sessions = this.sessions.filter(session => session.userId !== userId);
+            db.data.sessions = db.chain.get('sessions')
+                .reject({ userId })
+                .value();
         }
 
         const token = _.uniqueId('token_');
@@ -76,11 +60,16 @@ export class RuntimeData {
             expiresAt: new Date(Date.now() + 3600000), // 1 hour
         };
 
-        this.sessions.push(session);
+        db.data.sessions.push(session);
+        await db.write();
         return session;
     }
 
     async removeSession(userId: string) {
-        this.sessions = this.sessions.filter(session => session.userId !== userId);
+        const db = getDatabase();
+        db.data.sessions = db.chain.get('sessions')
+            .reject({ userId })
+            .value();
+        await db.write();
     }
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,38 @@
+import { Low } from 'lowdb';
+import { JSONFile } from 'lowdb/node';
+import lodash from 'lodash';
+import type { User, Session } from '@shared/types';
+import { Migrator } from './Migrator';
+
+export type DbData = {
+    users: User[];
+    sessions: Session[];
+    _migrations: string[];
+};
+
+const defaultData: DbData = {
+    users: [],
+    sessions: [],
+    _migrations: [],
+};
+
+export class LowWithLodash<T> extends Low<T> {
+    chain: lodash.ExpChain<this['data']> = lodash.chain(this).get('data');
+}
+
+const adapter = new JSONFile<DbData>('db.json');
+export const db = new LowWithLodash<DbData>(adapter, defaultData);
+
+export const initDatabase = async () => {
+    await db.read();
+    db.data ||= defaultData;
+    await new Migrator(db).migrate();
+    await db.write();
+};
+
+export const getDatabase = (): LowWithLodash<DbData> => {
+    if (!db.data) {
+        throw new Error('Database not initialized');
+    }
+    return db;
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,9 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { RPCHandler } from '@orpc/server/fetch';
 import { rpcRouter } from './rpcRouter';
+import { initDatabase } from './db';
+
+await initDatabase();
 
 const app = new Hono();
 app.use(cors());

--- a/server/src/rpcRouter.ts
+++ b/server/src/rpcRouter.ts
@@ -1,6 +1,5 @@
 import { RuntimeData } from './RuntimeData';
 import { withAuth, osWithHeaders } from './middlewares/withAuth';
-import _ from 'lodash';
 
 const osHeaders = osWithHeaders;
 const data = new RuntimeData();
@@ -12,13 +11,7 @@ export const rpcRouter = osHeaders.router({
         }),
         login: osHeaders.auth.login.handler(async ({ input }) => {
             const { id, password } = input;
-            const user = _.find(data.users, { id, password });
-
-            if (!user) {
-                throw new Error('Invalid credentials');
-            }
-
-            return await data.spawnSession(user.id);
+            return await data.login(id, password);
         }),
         whoami: osHeaders.auth.whoami
             .use(withAuth(data))

--- a/server/src/utils/generateUniqueId.ts
+++ b/server/src/utils/generateUniqueId.ts
@@ -1,0 +1,7 @@
+export const generateUniqueId = (usedIds: string[] = []): string => {
+    let id: string;
+    do {
+        id = crypto.randomUUID();
+    } while (usedIds.includes(id));
+    return id;
+};

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -21,6 +21,6 @@
         "moduleResolution": "bundler",
         "allowImportingTsExtensions": false
     },
-    "include": ["src/**/*"],
+    "include": ["src/**/*", "migrations/**/*"],
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- switch server to lowdb database and provide lodash-chain interface
- keep runtime user/session data in the new database
- create `Migrator` utility to run missing migration files
- update RPC login to use new RuntimeData
- add `getDatabase` helper and tweak init style
- refine migrator integration and default-user seeding
- refine migration and use lodash chaining
- return database instance from `getDatabase`
- use chain API in RuntimeData and migration

## Testing
- `bun run build:server`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68407f7c2af48329aa58a60bd6c963f9